### PR TITLE
Track offsets by assigning partitions and seek to end

### DIFF
--- a/src/main/java/com/redbeard/offsets/TopicOffsetConsumer.java
+++ b/src/main/java/com/redbeard/offsets/TopicOffsetConsumer.java
@@ -35,8 +35,11 @@ public class TopicOffsetConsumer {
     public Long getOffset(String topic) {
         List<TopicPartition> partitions = getPartitions(topic);
 
-        return kafkaConsumer.endOffsets(partitions)
-                .values().stream()
+        kafkaConsumer.assign(partitions);
+        kafkaConsumer.seekToEnd(partitions);
+
+        return partitions.stream()
+                .map(partition -> kafkaConsumer.position(partition))
                 .reduce(0L, Long::sum);
     }
 


### PR DESCRIPTION
This will return a higher offset if there are open transactions when using `read_committed`. Using `endOffset` will only return the last stable offset (LSO).

See [KafkaConsumer.endOffset](https://kafka.apache.org/28/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html#endOffsets(java.util.Collection))